### PR TITLE
Add Google Drive mime types

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "jest --config jestconfig.json",
     "build": "tsc",
-    "format": "prettier --write \"src/**/*.ts\" \"src/**/*.js\"",
+    "format": "prettier --print-width 100 --quote-props preserve --trailing-comma none --write \"src/**/*.ts\"",
     "lint": "tslint -p tsconfig.json",
     "prepare": "npm run build",
     "prepublishOnly": "npm test && npm run lint",

--- a/src/__tests__/resolveGoogleTypes.test.ts
+++ b/src/__tests__/resolveGoogleTypes.test.ts
@@ -1,0 +1,15 @@
+import { resolveFileType, resolveMime, resolveName} from "../index";
+
+describe("resolves Google file types", () => {
+test("resolveFileType", () => {
+  expect(resolveFileType(".google-apps.spreadsheet").mime).toBe("application/vnd.google-apps.spreadsheet");
+});
+
+test("resolveMime", () => {
+    expect(resolveMime("application/vnd.google-apps.shortcut").fileType).toBe(".google-apps.shortcut");
+  });
+  
+test("Resolve name test", () => {
+    expect(resolveName("Google Slides")[0].fileType).toBe(".google-apps.presentation");
+  });
+})

--- a/src/data.ts
+++ b/src/data.ts
@@ -3428,5 +3428,90 @@ export const data = [
     "mime": "application/vnd.zzazz.deck+xml",
     "name": "Zzazz Deck",
     "fileType": ".zaz"
+  },
+  {
+    "mime": "application/vnd.google-apps.audio",
+    "name": "Google Audio",
+    "fileType": ".vnd.google-apps.audio"
+  },
+  {
+    "mime": "application/vnd.google-apps.document",
+    "name": "Google Docs",
+    "fileType": ".google-apps.document"
+  },
+  {
+    "mime": "application/vnd.google-apps.drive-sdk",
+    "name": "3rd party shortcut",
+    "fileType": ".google-apps.drive-sdk"
+  },
+  {
+    "mime": "application/vnd.google-apps.drawing",
+    "name": "Google Drawing",
+    "fileType": ".google-apps.drawing"
+  },
+  {
+    "mime": "application/vnd.google-apps.file",
+    "name": "Google Drive file",
+    "fileType": ".google-apps.file"
+  },
+  {
+    "mime": "application/vnd.google-apps.folder",
+    "name": "Google Drive folder",
+    "fileType": ".google-apps.folder"
+  },
+  {
+    "mime": "application/vnd.google-apps.form",
+    "name": "Google Forms",
+    "fileType": ".google-apps.form"
+  },
+  {
+    "mime": "application/vnd.google-apps.fusiontable",
+    "name": "Google Fusion Tables",
+    "fileType": ".google-apps.fusiontable"
+  },
+  {
+    "mime": "application/vnd.google-apps.map",
+    "name": "Google My Maps",
+    "fileType": ".google-apps.map"
+  },
+  {
+    "mime": "application/vnd.google-apps.photo",
+    "name": "Google Photo",
+    "fileType": ".google-apps.photo"
+  },
+  {
+    "mime": "application/vnd.google-apps.presentation",
+    "name": "Google Slides",
+    "fileType": ".google-apps.presentation"
+  },
+  {
+    "mime": "application/vnd.google-apps.script",
+    "name": "Google Apps Scripts",
+    "fileType": ".google-apps.script"
+  },
+  {
+    "mime": "application/vnd.google-apps.shortcut",
+    "name": "Shortcut",
+    "fileType": ".google-apps.shortcut"
+  },
+  {
+    "mime": "application/vnd.google-apps.site",
+    "name": "Google Sites",
+    "fileType": ".google-apps.site"
+  },
+  {
+    "mime": "application/vnd.google-apps.spreadsheet",
+    "name": "Google Sheets",
+    "fileType": ".google-apps.spreadsheet"
+  },
+  {
+    "mime": "application/vnd.google-apps.unknown",
+    "name": "Google Unknown File",
+    "fileType": ".google-apps.unknown"
+  },
+  {
+    "mime": "application/vnd.google-apps.video",
+    "name": "Google VIdeo",
+    "fileType": ".google-apps.video"
   }
 ]


### PR DESCRIPTION
Google's types are outlined here: https://developers.google.com/drive/api/v3/mime-types

Because Google doesn't really use file extensions, I just used the suffix of the mime type for the file extensions.

I also added an extra commit that formats `data.ts` properly using `npm run format` - that commit isn't necessary for the new types, so it can be left off if you'd like. I didn't fix the formatter to preserve any of the other files.