### PR TITLE
feat: add new ico mimetype

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -236,6 +236,7 @@ application/vnd.ibm.secure-container,IBM Electronic Media Management System - Se
 text/calendar,iCalendar,.ics
 application/vnd.iccprofile,ICC profile,.icc
 image/x-icon,Icon Image,.ico
+image/vnd.microsoft.icon,Icon Image,.ico
 application/vnd.igloader,igLoader,.igl
 image/ief,Image Exchange Format,.ief
 application/vnd.immervision-ivp,ImmerVision PURE Players,.ivp


### PR DESCRIPTION
Added a new mimetype for `.ico`.

It'd be great if this would be added & published since I have a dependency on it. Otherwise I'd be forced to find a workaround.

@kirananto Please take a look. Thank you!