### PR TITLE
Support Apple iWork MIME types

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -706,4 +706,7 @@ application/vnd.google-apps.unknown,Google Unknown File,.google-apps.unknown
 application/vnd.google-apps.video,Google Video,.google-apps.video
 text/x-python,Python,.py
 application/x-zip-compressed,Compressed Archive (zip),.zip
-application/vnd.ms-outlook,Outlook mail message,.msg`;
+application/vnd.ms-outlook,Outlook mail message,.msg
+application/x-iwork-pages-sffpages,Apple Pages,.pages
+application/x-iwork-keynote-sffkey,Apple Keynote,.key
+application/x-iwork-numbers-sffnumbers,Apple Numbers,.numbers`;


### PR DESCRIPTION
Pages, Numbers and Keynote files all fail to resolve, these are uncommon, but do appear in user submitted content so should be supported.
